### PR TITLE
Fix compatibility with DyNet v2.0, add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:14.04
+
+# Deps of eigen, dynet and modlm
+RUN apt-get update && apt-get install -y vim git mercurial && \
+    apt-get install -y build-essential cmake && \
+    apt-get install -y libtool autotools-dev libboost1.54-all-dev autoconf bc
+
+ENV PROJECT_DIR /scratch/modlm_project
+RUN mkdir -p $PROJECT_DIR && \
+    useradd -ms /bin/bash ubuntu && \
+    chown -R ubuntu:ubuntu $PROJECT_DIR
+
+USER ubuntu
+WORKDIR $PROJECT_DIR
+
+# Download the code
+RUN hg clone https://bitbucket.org/eigen/eigen/ -r 346ecdb && \
+    git clone https://github.com/clab/dynet && \
+    git clone https://github.com/alancucki/modlm.git
+
+# Compile dynet
+RUN cd dynet && git checkout tags/v2.0 && \
+    mkdir build && cd build && \
+    cmake .. -DEIGEN3_INCLUDE_DIR=$PROJECT_DIR/eigen/ -DENABLE_CPP_EXAMPLES=ON && \
+    make -j 4
+
+ENV LD_LIBRARY_PATH $PROJECT_DIR/dynet/build/dynet:$LD_LIBRARY_PATH
+
+# Compile modlm
+RUN cd modlm && \
+    autoreconf -i && \
+    ./configure --with-dynet=$PROJECT_DIR/dynet --with-eigen=$PROJECT_DIR/eigen && \
+    make -j 4
+
+WORKDIR $PROJECT_DIR/modlm

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@ modlm: A toolkit for mixture of distributions language models
 ==============================================================================
 by Graham Neubig (neubig@is.naist.jp)
 
+Docker
+------
+
+The dockerfile sets up modlm for training, all dependencies included:
+```
+docker build -t modlm:latest .
+```
+
 Install
 -------
 
@@ -12,7 +20,16 @@ you are on Ubuntu/Debian linux, you can install them below:
 
 You must install Eigen and dynet separately. Follow the directions on the
 [dynet page](http://github.com/clab/dynet), which also explain about installing Eigen.
-Note that you should use the "v2" branch of dynet.
+Note that you should use the version of dynet tagged `v2.0` (commit [1241cfc](https://github.com/clab/dynet/commit/1241cfc3e4e1915d6b7b3914b36b997a8a522397)),
+and `eigen` from changeset `346ecdb`, according to the [docs](https://github.com/clab/dynet/blob/1241cfc3e4e1915d6b7b3914b36b997a8a522397/doc/source/install.rst).
+
+```
+git clone https://github.com/clab/dynet
+cd dynet ; git checkout tags/v2.0 ; cd ..
+hg clone https://bitbucket.org/eigen/eigen/ -r 346ecdb
+
+# NOTE Compile dynet, before proceeding with modlm
+```
 
 Once these two packages are installed, run the following commands, specifying the
 correct paths for dynet and Eigen.

--- a/example/preproc.sh
+++ b/example/preproc.sh
@@ -2,7 +2,7 @@
 set -e
 set -o pipefail
 
-MDIR=`pwd`/../modlm
+MDIR=`pwd`/..
 
 # SUF=wsj
 # LANG=txt

--- a/example/process.sh
+++ b/example/process.sh
@@ -5,7 +5,7 @@ set -e
 MEM=0512
 MINIBATCH=0512
 SEED=100
-MDIR=`pwd`/../modlm
+MDIR=`pwd`/..
 DEVEPOCHS=1
 
 DTYPE=ptb

--- a/src/modlm/ff-builder.cc
+++ b/src/modlm/ff-builder.cc
@@ -8,7 +8,6 @@
 #include <iostream>
 
 using namespace std;
-using namespace dynet::expr;
 
 namespace dynet {
 
@@ -18,10 +17,11 @@ FFBuilder::FFBuilder(unsigned layers,
                        unsigned input_dim,
                        unsigned hidden_dim,
                        Model& model) : layers(layers), dropout_rate(0.f) {
+  local_model = model.add_subcollection("ff-builder");
   unsigned layer_input_dim = input_dim;
   for (unsigned i = 0; i < layers; ++i) {
-    Parameter p_x2h = model.add_parameters({hidden_dim, layer_input_dim});
-    Parameter p_hb = model.add_parameters({hidden_dim});
+    Parameter p_x2h = local_model.add_parameters({hidden_dim, layer_input_dim});
+    Parameter p_hb = local_model.add_parameters({hidden_dim}); //, ParameterInitConst(0.f));
     params.push_back({p_x2h, p_hb});
     layer_input_dim = hidden_dim;
   }

--- a/src/modlm/ff-builder.h
+++ b/src/modlm/ff-builder.h
@@ -5,8 +5,6 @@
 #include <dynet/rnn-state-machine.h>
 #include <dynet/expr.h>
 
-using namespace dynet::expr;
-
 namespace dynet {
 
 class Model;
@@ -40,6 +38,8 @@ struct FFBuilder : public RNNBuilder {
 
   unsigned num_h0_components() const override { return 0; }
 
+  ParameterCollection & get_parameter_collection() { return local_model; }
+
  private:
   // first index is layer, then x2h hb
   std::vector<std::vector<Parameter> > params;
@@ -50,6 +50,8 @@ struct FFBuilder : public RNNBuilder {
   // initial value of h
   // defaults to zero matrix input
   std::vector<Expression> h0;
+
+  ParameterCollection local_model;
 
   float dropout_rate;
 

--- a/src/modlm/modlm-train.cc
+++ b/src/modlm/modlm-train.cc
@@ -6,11 +6,10 @@
 #include <boost/program_options.hpp>
 #include <boost/range/irange.hpp>
 #include <boost/algorithm/string.hpp>
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
 #include <dynet/expr.h>
 #include <dynet/dynet.h>
 #include <dynet/dict.h>
+#include "dynet/io.h"
 #include <dynet/training.h>
 #include <dynet/rnn.h>
 #include <dynet/lstm.h>
@@ -30,7 +29,7 @@
 #include <modlm/input-file-stream.h>
 
 using namespace std;
-using namespace dynet::expr;
+using namespace dynet;
 namespace po = boost::program_options;
 
 namespace modlm {
@@ -616,10 +615,8 @@ void ModlmTrain::perform_training() {
         last_valid = valid_loss;
         // Open the output model
         if(best_valid > valid_loss && model_out_file_ != "") {
-          ofstream out(model_out_file_.c_str());
-          if(!out) THROW_ERROR("Could not open output file: " << model_out_file_);
-          boost::archive::text_oarchive oa(out);
-          oa << *mod_;
+          dynet::TextFileSaver saver(model_out_file_.c_str());
+          saver.save(*mod_);
           best_valid = valid_loss;
         }
       }
@@ -982,10 +979,8 @@ int ModlmTrain::main(int argc, char** argv) {
 
   // Open the input model
   if(model_in_file_ != "") {
-    ifstream in(model_in_file_.c_str());
-    if(!in) THROW_ERROR("Could not open input file: " << model_in_file_);
-    boost::archive::text_iarchive ia(in);
-    ia >> *mod_;
+    dynet::TextFileLoader loader(model_in_file_.c_str());
+    loader.populate(*mod_);
   }
 
   // Actually perform training

--- a/src/modlm/modlm-train.h
+++ b/src/modlm/modlm-train.h
@@ -54,7 +54,7 @@ protected:
 
   // *** Create the graph
 
-  dynet::expr::Expression add_to_graph(size_t mb_num_sent, const std::vector<float> & wctxt, const std::vector<Sentence> & ctxt_ngrams, const std::vector<float> & wdists, const std::vector<float> & wcnts, bool dropout, dynet::ComputationGraph & cg);
+  dynet::Expression add_to_graph(size_t mb_num_sent, const std::vector<float> & wctxt, const std::vector<Sentence> & ctxt_ngrams, const std::vector<float> & wdists, const std::vector<float> & wcnts, bool dropout, dynet::ComputationGraph & cg);
 
   template <class Data, class Instance>
   float calc_instance(const Data & data, int minibatch, bool update, std::pair<int,int> epoch, std::pair<int,int> & words);
@@ -105,8 +105,8 @@ protected:
 
   dynet::LookupParameter reps_;
   BuilderPtr builder_;
-  dynet::Parameter V_; dynet::expr::Expression V_expr_;
-  dynet::Parameter a_; dynet::expr::Expression a_expr_;
+  dynet::Parameter V_; dynet::Expression V_expr_;
+  dynet::Parameter a_; dynet::Expression a_expr_;
 
   float log_unk_prob_;
   int max_ctxt_, num_ctxt_, num_dense_dist_, num_sparse_dist_;


### PR DESCRIPTION
Readme states, that modlm requires v2 branch of DyNet, which no longer exists. DyNet tagged v2.0 is incompatible.

This request fixes compatibility with DyNet tagged v2.0, which no longer serializes models with boost archives. It also adds Dockerfile which allows to run modlm straight out of the box.

NB this probably resolves https://github.com/neubig/modlm/issues/1 , as I had similar segfaults with improper versions of DyNet/Eigen.